### PR TITLE
즉시 구매 기능 리팩토링

### DIFF
--- a/src/main/java/api/soldout/io/soldout/dtos/entity/OrderDto.java
+++ b/src/main/java/api/soldout/io/soldout/dtos/entity/OrderDto.java
@@ -2,6 +2,7 @@ package api.soldout.io.soldout.dtos.entity;
 
 import api.soldout.io.soldout.util.enums.OrderType;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,20 +15,37 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class OrderDto {
 
+  /**
+   * .
+   */
+
+  @Getter
+  @AllArgsConstructor
+  public enum OrderStatus {
+
+    ORDER_PROGRESS("입찰 진행중"),
+    ORDER_SIGNED("거래 완료");
+
+    private final String text;
+
+  }
+
   private int id;
   private int userId;
   private int productId;
   private int size;
   private int price;
-  private OrderType type;
   private LocalDateTime day;
+  private OrderType type;
+  private OrderStatus status;
 
   /**
    * .
    */
 
   @Builder
-  public OrderDto(int id, int userId, int productId, int size, int price, int day, OrderType type) {
+  public OrderDto(int id, int userId, int productId, int size, int price, int day,
+                  OrderType type, OrderStatus status) {
 
     this.id = id;
     this.userId = userId;
@@ -36,6 +54,7 @@ public class OrderDto {
     this.price = price;
     this.type = type;
     this.day = LocalDateTime.now().plusDays(day);
+    this.status = status;
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/dtos/entity/OrderDto.java
+++ b/src/main/java/api/soldout/io/soldout/dtos/entity/OrderDto.java
@@ -23,8 +23,8 @@ public class OrderDto {
   @AllArgsConstructor
   public enum OrderStatus {
 
-    ORDER_PROGRESS("입찰 진행중"),
-    ORDER_SIGNED("거래 완료");
+    BID_PROGRESS("입찰 진행 중"),
+    MATCHING_COMPLETE("거래 체결 완료");
 
     private final String text;
 
@@ -35,7 +35,7 @@ public class OrderDto {
   private int productId;
   private int size;
   private int price;
-  private LocalDateTime day;
+  private LocalDateTime date;
   private OrderType type;
   private OrderStatus status;
 
@@ -44,7 +44,7 @@ public class OrderDto {
    */
 
   @Builder
-  public OrderDto(int id, int userId, int productId, int size, int price, int day,
+  public OrderDto(int id, int userId, int productId, int size, int price, int date,
                   OrderType type, OrderStatus status) {
 
     this.id = id;
@@ -53,7 +53,7 @@ public class OrderDto {
     this.size = size;
     this.price = price;
     this.type = type;
-    this.day = LocalDateTime.now().plusDays(day);
+    this.date = LocalDateTime.now().plusDays(date);
     this.status = status;
 
   }

--- a/src/main/java/api/soldout/io/soldout/dtos/entity/SaleDto.java
+++ b/src/main/java/api/soldout/io/soldout/dtos/entity/SaleDto.java
@@ -2,6 +2,7 @@ package api.soldout.io.soldout.dtos.entity;
 
 import api.soldout.io.soldout.util.enums.SaleType;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,28 +15,45 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SaleDto {
 
+  /**
+   * .
+   */
+
+  @Getter
+  @AllArgsConstructor
+  public enum SaleStatus {
+
+    SALE_PROGRESS("입찰 진행중"),
+    SALE_SIGNED("거래 완료");
+
+    private final String text;
+
+  }
+
   private int id;
   private int userId;
   private int productId;
   private int size;
   private int price;
-  private SaleType type;
   private LocalDateTime day;
+  private SaleType type;
+  private SaleStatus status;
 
   /**
    * .
    */
 
   @Builder
-  public SaleDto(int id, int userId, int productId, int size, int price, int day, SaleType type) {
+  public SaleDto(int userId, int productId, int size, int price, int day,
+                 SaleType type, SaleStatus status) {
 
-    this.id = id;
     this.userId = userId;
     this.productId = productId;
     this.size = size;
     this.price = price;
-    this.type = type;
     this.day = LocalDateTime.now().plusDays(day);
+    this.type = type;
+    this.status = status;
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/dtos/entity/SaleDto.java
+++ b/src/main/java/api/soldout/io/soldout/dtos/entity/SaleDto.java
@@ -41,12 +41,14 @@ public class SaleDto {
 
   /**
    * .
+   *
    */
 
   @Builder
-  public SaleDto(int userId, int productId, int size, int price, int day,
+  public SaleDto(int id, int userId, int productId, int size, int price, int day,
                  SaleType type, SaleStatus status) {
 
+    this.id = id;
     this.userId = userId;
     this.productId = productId;
     this.size = size;

--- a/src/main/java/api/soldout/io/soldout/dtos/entity/SaleDto.java
+++ b/src/main/java/api/soldout/io/soldout/dtos/entity/SaleDto.java
@@ -23,8 +23,8 @@ public class SaleDto {
   @AllArgsConstructor
   public enum SaleStatus {
 
-    SALE_PROGRESS("입찰 진행중"),
-    SALE_SIGNED("거래 완료");
+    BID_PROGRESS("입찰 진행 중"),
+    MATCHING_COMPLETE("거래 체결 완료");
 
     private final String text;
 
@@ -35,7 +35,7 @@ public class SaleDto {
   private int productId;
   private int size;
   private int price;
-  private LocalDateTime day;
+  private LocalDateTime date;
   private SaleType type;
   private SaleStatus status;
 
@@ -45,7 +45,7 @@ public class SaleDto {
    */
 
   @Builder
-  public SaleDto(int id, int userId, int productId, int size, int price, int day,
+  public SaleDto(int id, int userId, int productId, int size, int price, int date,
                  SaleType type, SaleStatus status) {
 
     this.id = id;
@@ -53,7 +53,7 @@ public class SaleDto {
     this.productId = productId;
     this.size = size;
     this.price = price;
-    this.day = LocalDateTime.now().plusDays(day);
+    this.date = LocalDateTime.now().plusDays(date);
     this.type = type;
     this.status = status;
 

--- a/src/main/java/api/soldout/io/soldout/dtos/entity/TradeDto.java
+++ b/src/main/java/api/soldout/io/soldout/dtos/entity/TradeDto.java
@@ -22,15 +22,15 @@ public class TradeDto {
   @AllArgsConstructor
   public enum TradeStatus {
 
-    TRADE_SIGNING("거래체결"),
-    DELIVER_FROM_SALE_WAIT("판매자 발송 대기 중"),
-    DELIVER_FROM_SALE_COMPLETE("판매자 발송 완료"),
+    MATCHING_COMPLETE("거래 체결 완료"),
+    DELIVER_FROM_SELLER_WAIT("판매자 발송 대기 중"),
+    DELIVER_FROM_SELLER_COMPLETE("판매자 발송 완료"),
     INSPECTION_ARRIVAL("검수센터 도착"),
     INSPECTION_INSPECTING("검수센터 검수 중"),
     INSPECTION_PASS("검수센터 검수 통과"),
     DELIVER_TO_ORDER_DELIVERING("배송 중"),
     DELIVER_TO_ORDER_ARRIVAL("배송 도착"),
-    TRADE_COMPLETE("거래완료");
+    TRADE_COMPLETE("거래 완료");
 
     private final String text;
 
@@ -43,6 +43,6 @@ public class TradeDto {
   private int size;
   private int price;
   private TradeStatus status;
-  private LocalDateTime day;
+  private LocalDateTime date;
 
 }

--- a/src/main/java/api/soldout/io/soldout/dtos/entity/TradeDto.java
+++ b/src/main/java/api/soldout/io/soldout/dtos/entity/TradeDto.java
@@ -1,6 +1,6 @@
 package api.soldout.io.soldout.dtos.entity;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,6 +43,6 @@ public class TradeDto {
   private int size;
   private int price;
   private TradeStatus status;
-  private LocalDate day;
+  private LocalDateTime day;
 
 }

--- a/src/main/java/api/soldout/io/soldout/exception/AlreadyMatchedException.java
+++ b/src/main/java/api/soldout/io/soldout/exception/AlreadyMatchedException.java
@@ -1,0 +1,19 @@
+package api.soldout.io.soldout.exception;
+
+/**
+ * .
+ */
+
+public class AlreadyMatchedException extends RuntimeException {
+
+  /**
+   *.
+   */
+
+  public AlreadyMatchedException(String message) {
+
+    super(message);
+
+  }
+
+}

--- a/src/main/java/api/soldout/io/soldout/exception/hadler/ExceptionHandlerAdvice.java
+++ b/src/main/java/api/soldout/io/soldout/exception/hadler/ExceptionHandlerAdvice.java
@@ -3,6 +3,7 @@ package api.soldout.io.soldout.exception.hadler;
 import api.soldout.io.soldout.dtos.response.ResponseDto;
 import api.soldout.io.soldout.dtos.response.ResponseDto.Error;
 import api.soldout.io.soldout.exception.AlreadyExistEmailException;
+import api.soldout.io.soldout.exception.AlreadyMatchedException;
 import api.soldout.io.soldout.exception.AlreadySignInBrowserException;
 import api.soldout.io.soldout.exception.NotSignInBrowserException;
 import api.soldout.io.soldout.exception.NotValidEmailException;
@@ -95,6 +96,18 @@ public class ExceptionHandlerAdvice {
     return fail("Unauthorized", e.getMessage());
 
   }
+
+  /**
+   * .
+   */
+
+  @ExceptionHandler(AlreadyMatchedException.class)
+  public ResponseDto alreadyMatchedException(AlreadyMatchedException e) {
+
+    return fail("Accepted", e.getMessage());
+
+  }
+
 
   /**
    * .

--- a/src/main/java/api/soldout/io/soldout/mapper/OrderMapper.java
+++ b/src/main/java/api/soldout/io/soldout/mapper/OrderMapper.java
@@ -1,8 +1,10 @@
 package api.soldout.io.soldout.mapper;
 
 import api.soldout.io.soldout.dtos.entity.OrderDto;
+import api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 /**
  * .
@@ -16,5 +18,7 @@ public interface OrderMapper {
   List<OrderDto> findByUserId(String userId);
 
   List<OrderDto> findByProductId(String productId);
+
+  void updateOrderStatus(@Param("orderId") int saleId, @Param("status") OrderStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/mapper/OrderMapper.java
+++ b/src/main/java/api/soldout/io/soldout/mapper/OrderMapper.java
@@ -19,6 +19,6 @@ public interface OrderMapper {
 
   List<OrderDto> findByProductId(String productId);
 
-  void updateOrderStatus(@Param("orderId") int saleId, @Param("status") OrderStatus status);
+  void updateOrderStatus(@Param("orderId") int orderId, @Param("status") OrderStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/mapper/SaleMapper.java
+++ b/src/main/java/api/soldout/io/soldout/mapper/SaleMapper.java
@@ -1,8 +1,10 @@
 package api.soldout.io.soldout.mapper;
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
+import api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 /**
  * .
@@ -16,5 +18,7 @@ public interface SaleMapper {
   List<SaleDto> findByUserId(int userId);
 
   List<SaleDto> findByProductId(int productId);
+
+  void updateSaleStatus(@Param("saleId") int saleId, @Param("status") SaleStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/mapper/TradeMapper.java
+++ b/src/main/java/api/soldout/io/soldout/mapper/TradeMapper.java
@@ -1,6 +1,7 @@
 package api.soldout.io.soldout.mapper;
 
 import api.soldout.io.soldout.dtos.entity.TradeDto;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 /**
@@ -11,5 +12,9 @@ import org.apache.ibatis.annotations.Mapper;
 public interface TradeMapper {
 
   void insertTrade(TradeDto tradeDto);
+
+  List<TradeDto> findByOrderId(int orderId);
+
+  List<TradeDto> findBySaleId(int saleId);
 
 }

--- a/src/main/java/api/soldout/io/soldout/repository/order/OrderRepository.java
+++ b/src/main/java/api/soldout/io/soldout/repository/order/OrderRepository.java
@@ -1,6 +1,7 @@
 package api.soldout.io.soldout.repository.order;
 
 import api.soldout.io.soldout.dtos.entity.OrderDto;
+import api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus;
 import java.util.List;
 
 /**
@@ -14,5 +15,7 @@ public interface OrderRepository {
   List<OrderDto> findByUserId(String userId);
 
   List<OrderDto> findByProductId(String productId);
+
+  void updateOrderStatus(int saleId, OrderStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/repository/order/OrderRepository.java
+++ b/src/main/java/api/soldout/io/soldout/repository/order/OrderRepository.java
@@ -16,6 +16,6 @@ public interface OrderRepository {
 
   List<OrderDto> findByProductId(String productId);
 
-  void updateOrderStatus(int saleId, OrderStatus status);
+  void updateOrderStatus(int orderId, OrderStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/repository/order/OrderRepositoryImpl.java
+++ b/src/main/java/api/soldout/io/soldout/repository/order/OrderRepositoryImpl.java
@@ -1,6 +1,7 @@
 package api.soldout.io.soldout.repository.order;
 
 import api.soldout.io.soldout.dtos.entity.OrderDto;
+import api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus;
 import api.soldout.io.soldout.mapper.OrderMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,13 @@ public class OrderRepositoryImpl implements OrderRepository {
   public List<OrderDto> findByProductId(String productId) {
 
     return orderMapper.findByProductId(productId);
+
+  }
+
+  @Override
+  public void updateOrderStatus(int saleId, OrderStatus status) {
+
+    orderMapper.updateOrderStatus(saleId, status);
 
   }
 }

--- a/src/main/java/api/soldout/io/soldout/repository/order/OrderRepositoryImpl.java
+++ b/src/main/java/api/soldout/io/soldout/repository/order/OrderRepositoryImpl.java
@@ -41,9 +41,9 @@ public class OrderRepositoryImpl implements OrderRepository {
   }
 
   @Override
-  public void updateOrderStatus(int saleId, OrderStatus status) {
+  public void updateOrderStatus(int orderId, OrderStatus status) {
 
-    orderMapper.updateOrderStatus(saleId, status);
+    orderMapper.updateOrderStatus(orderId, status);
 
   }
 }

--- a/src/main/java/api/soldout/io/soldout/repository/sale/SaleRepository.java
+++ b/src/main/java/api/soldout/io/soldout/repository/sale/SaleRepository.java
@@ -1,6 +1,7 @@
 package api.soldout.io.soldout.repository.sale;
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
+import api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus;
 import java.util.List;
 
 /**
@@ -14,5 +15,7 @@ public interface SaleRepository {
   List<SaleDto> findByUserId(int userId);
 
   List<SaleDto> findByProductId(int productId);
+
+  void updateSaleStatus(int saleId, SaleStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/repository/sale/SaleRepositoryImpl.java
+++ b/src/main/java/api/soldout/io/soldout/repository/sale/SaleRepositoryImpl.java
@@ -1,6 +1,7 @@
 package api.soldout.io.soldout.repository.sale;
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
+import api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus;
 import api.soldout.io.soldout.mapper.SaleMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,13 @@ public class SaleRepositoryImpl implements SaleRepository {
   public List<SaleDto> findByProductId(int productId) {
 
     return saleMapper.findByProductId(productId);
+
+  }
+
+  @Override
+  public void updateSaleStatus(int saleId, SaleStatus status) {
+
+    saleMapper.updateSaleStatus(saleId, status);
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/repository/trade/TradeRepository.java
+++ b/src/main/java/api/soldout/io/soldout/repository/trade/TradeRepository.java
@@ -1,6 +1,7 @@
 package api.soldout.io.soldout.repository.trade;
 
 import api.soldout.io.soldout.dtos.entity.TradeDto;
+import java.util.List;
 
 /**
  * .
@@ -9,5 +10,9 @@ import api.soldout.io.soldout.dtos.entity.TradeDto;
 public interface TradeRepository {
 
   void saveTrade(TradeDto tradeDto);
+
+  List<TradeDto> findByOrderId(int orderId);
+
+  List<TradeDto> findBySaleId(int saleId);
 
 }

--- a/src/main/java/api/soldout/io/soldout/repository/trade/TradeRepositoryImpl.java
+++ b/src/main/java/api/soldout/io/soldout/repository/trade/TradeRepositoryImpl.java
@@ -2,6 +2,7 @@ package api.soldout.io.soldout.repository.trade;
 
 import api.soldout.io.soldout.dtos.entity.TradeDto;
 import api.soldout.io.soldout.mapper.TradeMapper;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -19,6 +20,20 @@ public class TradeRepositoryImpl implements TradeRepository {
   public void saveTrade(TradeDto tradeDto) {
 
     tradeMapper.insertTrade(tradeDto);
+
+  }
+
+  @Override
+  public List<TradeDto> findByOrderId(int orderId) {
+
+    return tradeMapper.findByOrderId(orderId);
+
+  }
+
+  @Override
+  public List<TradeDto> findBySaleId(int saleId) {
+
+    return tradeMapper.findBySaleId(saleId);
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/service/order/OrderService.java
+++ b/src/main/java/api/soldout/io/soldout/service/order/OrderService.java
@@ -1,6 +1,7 @@
 package api.soldout.io.soldout.service.order;
 
 import api.soldout.io.soldout.dtos.entity.OrderDto;
+import api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus;
 import api.soldout.io.soldout.service.order.command.OrderCommand;
 import java.util.List;
 
@@ -15,5 +16,7 @@ public interface OrderService {
   List<OrderDto> findByUserId(String userId);
 
   List<OrderDto> findByProductId(String productId);
+
+  void updateOrderStatus(int saleId, OrderStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/service/order/OrderService.java
+++ b/src/main/java/api/soldout/io/soldout/service/order/OrderService.java
@@ -17,6 +17,6 @@ public interface OrderService {
 
   List<OrderDto> findByProductId(String productId);
 
-  void updateOrderStatus(int saleId, OrderStatus status);
+  void updateOrderStatus(int orderId, OrderStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
@@ -1,9 +1,6 @@
 package api.soldout.io.soldout.service.order;
 
 
-import static api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus.ORDER_PROGRESS;
-import static api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus.ORDER_SIGNED;
-
 import api.soldout.io.soldout.dtos.entity.OrderDto;
 import api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus;
 import api.soldout.io.soldout.repository.order.OrderRepository;
@@ -35,9 +32,9 @@ public class OrderServiceImpl implements OrderService {
         .productId(command.getProductId())
         .size(command.getSize())
         .price(command.getPrice())
-        .day(command.getPeriod())
+        .date(command.getPeriod())
         .type(command.getType())
-        .status(ORDER_PROGRESS)
+        .status(OrderStatus.BID_PROGRESS)
         .build();
 
     orderRepository.saveOrder(order);
@@ -46,7 +43,7 @@ public class OrderServiceImpl implements OrderService {
         order.getProductId(), order.getId(), order.getSize(), order.getPrice()
     );
 
-    orderRepository.updateOrderStatus(order.getId(), ORDER_SIGNED);
+    orderRepository.updateOrderStatus(order.getId(), OrderStatus.MATCHING_COMPLETE);
 
   }
 
@@ -65,9 +62,9 @@ public class OrderServiceImpl implements OrderService {
   }
 
   @Override
-  public void updateOrderStatus(int saleId, OrderStatus status) {
+  public void updateOrderStatus(int orderId, OrderStatus status) {
 
-    orderRepository.updateOrderStatus(saleId, status);
+    orderRepository.updateOrderStatus(orderId, status);
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
@@ -4,6 +4,7 @@ package api.soldout.io.soldout.service.order;
 import api.soldout.io.soldout.dtos.entity.OrderDto;
 import api.soldout.io.soldout.repository.order.OrderRepository;
 import api.soldout.io.soldout.service.order.command.OrderCommand;
+import api.soldout.io.soldout.service.trade.TradeService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,8 @@ public class OrderServiceImpl implements OrderService {
 
   private final OrderRepository orderRepository;
 
+  private final TradeService tradeService;
+
   @Override
   public void orderNow(OrderCommand command) {
 
@@ -33,6 +36,10 @@ public class OrderServiceImpl implements OrderService {
         .build();
 
     orderRepository.saveOrder(order);
+
+    tradeService.signTradeByOrder(
+        order.getProductId(), order.getId(), order.getSize(), order.getPrice()
+    );
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
@@ -40,7 +40,7 @@ public class OrderServiceImpl implements OrderService {
     orderRepository.saveOrder(order);
 
     tradeService.matchTradeByOrder(
-        order.getProductId(), order.getId(), order.getSize(), order.getPrice()
+        order.getId(), order.getProductId(), order.getSize(), order.getPrice()
     );
 
     orderRepository.updateOrderStatus(order.getId(), OrderStatus.MATCHING_COMPLETE);

--- a/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
@@ -1,7 +1,11 @@
 package api.soldout.io.soldout.service.order;
 
 
+import static api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus.ORDER_PROGRESS;
+import static api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus.ORDER_SIGNED;
+
 import api.soldout.io.soldout.dtos.entity.OrderDto;
+import api.soldout.io.soldout.dtos.entity.OrderDto.OrderStatus;
 import api.soldout.io.soldout.repository.order.OrderRepository;
 import api.soldout.io.soldout.service.order.command.OrderCommand;
 import api.soldout.io.soldout.service.trade.TradeService;
@@ -31,8 +35,9 @@ public class OrderServiceImpl implements OrderService {
         .productId(command.getProductId())
         .size(command.getSize())
         .price(command.getPrice())
-        .type(command.getType())
         .day(command.getPeriod())
+        .type(command.getType())
+        .status(ORDER_PROGRESS)
         .build();
 
     orderRepository.saveOrder(order);
@@ -40,6 +45,8 @@ public class OrderServiceImpl implements OrderService {
     tradeService.signTradeByOrder(
         order.getProductId(), order.getId(), order.getSize(), order.getPrice()
     );
+
+    orderRepository.updateOrderStatus(order.getId(), ORDER_SIGNED);
 
   }
 
@@ -54,6 +61,13 @@ public class OrderServiceImpl implements OrderService {
   public List<OrderDto> findByProductId(String productId) {
 
     return orderRepository.findByProductId(productId);
+
+  }
+
+  @Override
+  public void updateOrderStatus(int saleId, OrderStatus status) {
+
+    orderRepository.updateOrderStatus(saleId, status);
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/order/OrderServiceImpl.java
@@ -39,7 +39,7 @@ public class OrderServiceImpl implements OrderService {
 
     orderRepository.saveOrder(order);
 
-    tradeService.signTradeByOrder(
+    tradeService.matchTradeByOrder(
         order.getProductId(), order.getId(), order.getSize(), order.getPrice()
     );
 

--- a/src/main/java/api/soldout/io/soldout/service/sale/SaleService.java
+++ b/src/main/java/api/soldout/io/soldout/service/sale/SaleService.java
@@ -1,6 +1,7 @@
 package api.soldout.io.soldout.service.sale;
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
+import api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus;
 import api.soldout.io.soldout.service.sale.command.SaleBidCommand;
 import java.util.List;
 
@@ -15,5 +16,7 @@ public interface SaleService {
   List<SaleDto> findByUserId(int userId);
 
   List<SaleDto> findByProductId(int productId);
+
+  void updateSaleStatus(int saleId, SaleStatus status);
 
 }

--- a/src/main/java/api/soldout/io/soldout/service/sale/SaleServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/sale/SaleServiceImpl.java
@@ -1,8 +1,5 @@
 package api.soldout.io.soldout.service.sale;
 
-
-import static api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus.SALE_PROGRESS;
-
 import api.soldout.io.soldout.dtos.entity.SaleDto;
 import api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus;
 import api.soldout.io.soldout.repository.sale.SaleRepository;
@@ -35,9 +32,9 @@ public class SaleServiceImpl implements SaleService {
         .productId(command.getProductId())
         .size(command.getSize())
         .price(command.getPrice())
-        .day(command.getPeriod())
+        .date(command.getPeriod())
         .type(command.getType())
-        .status(SALE_PROGRESS)
+        .status(SaleStatus.BID_PROGRESS)
         .build();
 
     saleRepository.saveSale(saleDto);

--- a/src/main/java/api/soldout/io/soldout/service/sale/SaleServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/sale/SaleServiceImpl.java
@@ -4,6 +4,7 @@ package api.soldout.io.soldout.service.sale;
 import static api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus.SALE_PROGRESS;
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
+import api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus;
 import api.soldout.io.soldout.repository.sale.SaleRepository;
 import api.soldout.io.soldout.service.sale.command.SaleBidCommand;
 import java.util.List;
@@ -56,4 +57,12 @@ public class SaleServiceImpl implements SaleService {
     return saleRepository.findByProductId(productId);
 
   }
+
+  @Override
+  public void updateSaleStatus(int saleId, SaleStatus status) {
+
+    saleRepository.updateSaleStatus(saleId, status);
+
+  }
+
 }

--- a/src/main/java/api/soldout/io/soldout/service/sale/SaleServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/sale/SaleServiceImpl.java
@@ -1,6 +1,8 @@
 package api.soldout.io.soldout.service.sale;
 
 
+import static api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus.SALE_PROGRESS;
+
 import api.soldout.io.soldout.dtos.entity.SaleDto;
 import api.soldout.io.soldout.repository.sale.SaleRepository;
 import api.soldout.io.soldout.service.sale.command.SaleBidCommand;
@@ -32,8 +34,9 @@ public class SaleServiceImpl implements SaleService {
         .productId(command.getProductId())
         .size(command.getSize())
         .price(command.getPrice())
-        .type(command.getType())
         .day(command.getPeriod())
+        .type(command.getType())
+        .status(SALE_PROGRESS)
         .build();
 
     saleRepository.saveSale(saleDto);

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeService.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeService.java
@@ -1,5 +1,8 @@
 package api.soldout.io.soldout.service.trade;
 
+import api.soldout.io.soldout.dtos.entity.TradeDto;
+import java.util.List;
+
 /**
  * .
  */
@@ -7,5 +10,9 @@ package api.soldout.io.soldout.service.trade;
 public interface TradeService {
 
   void signTradeByOrder(int productId, int orderId, int size, int price);
+
+  List<TradeDto> findByOrderId(int orderId);
+
+  List<TradeDto> findBySaleId(int saleId);
 
 }

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeService.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface TradeService {
 
-  void matchTradeByOrder(int productId, int orderId, int size, int price);
+  void matchTradeByOrder(int orderId, int productId, int size, int price);
 
   List<TradeDto> findByOrderId(int orderId);
 

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeService.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface TradeService {
 
-  void signTradeByOrder(int productId, int orderId, int size, int price);
+  void matchTradeByOrder(int productId, int orderId, int size, int price);
 
   List<TradeDto> findByOrderId(int orderId);
 

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
@@ -1,12 +1,11 @@
 package api.soldout.io.soldout.service.trade;
 
 import static api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus.SALE_PROGRESS;
+import static api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus.SALE_SIGNED;
 import static api.soldout.io.soldout.dtos.entity.TradeDto.TradeStatus.TRADE_SIGNING;
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
-import api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus;
 import api.soldout.io.soldout.dtos.entity.TradeDto;
-import api.soldout.io.soldout.exception.AlreadyMatchedException;
 import api.soldout.io.soldout.repository.trade.TradeRepository;
 import api.soldout.io.soldout.service.sale.SaleService;
 import java.time.LocalDateTime;
@@ -47,8 +46,7 @@ public class TradeServiceImpl implements TradeService {
 
     tradeRepository.saveTrade(tradeDto);
 
-    // saleDto 의 상태를 변경 (입찰 -> 판매 완료)
-    // updateSaleStatus(saleId);
+    saleService.updateSaleStatus(saleId, SALE_SIGNED);
 
   }
 
@@ -82,7 +80,7 @@ public class TradeServiceImpl implements TradeService {
 
     }
 
-    return 0;
+    throw new RuntimeException("어떠한 이유로 매칭되어야 할 판매 입찰가가 사라진 경우");
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
@@ -28,7 +28,7 @@ public class TradeServiceImpl implements TradeService {
   private final SaleRepository saleRepository;
 
   @Override
-  public void signTradeByOrder(int productId, int orderId, int size, int price) {
+  public void matchTradeByOrder(int productId, int orderId, int size, int price) {
 
     List<SaleDto> saleDtoList = saleRepository.findByProductId(productId);
 

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
@@ -70,7 +70,7 @@ public class TradeServiceImpl implements TradeService {
 
   private int findMatchedSaleDto(List<SaleDto> saleDtoList, int size, int price) {
 
-    // id가 기본적으로 인덱스로 사용되고 자동 증가로 입력되기 때문에 그 순서로 루프를 수행 -> 생성 시기가 빠른 녀석을 찾기 위한 로직이 굳이 필요할지?
+    // id가 기본적으로 인덱스로 사용되고 자동 증가로 입력되기 때문에 그 순서로 루프를 수행
     for (SaleDto tempSaleDto : saleDtoList) {
 
       if (tempSaleDto.getSize() == size && tempSaleDto.getPrice() == price) {
@@ -83,6 +83,7 @@ public class TradeServiceImpl implements TradeService {
 
     // 그래도 찾고자 하는 saleId가 없다면?
     // 어떠한 이유로 구매 버튼을 누른 시점에 존재했던 SaleId가 없어진 경우
+    // 에러 처리를 할 경우가 생길지 고민해 봐야 한다.
     throw new RuntimeException("판매 입찰 기간이 지나서 갑작스럽게 매칭 가능한 판매자가 사라진 경우");
 
   }

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
@@ -1,10 +1,10 @@
 package api.soldout.io.soldout.service.trade;
 
-import static api.soldout.io.soldout.dtos.entity.TradeDto.TradeStatus.DELIVER_FROM_SALE_COMPLETE;
 import static api.soldout.io.soldout.dtos.entity.TradeDto.TradeStatus.TRADE_SIGNING;
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
 import api.soldout.io.soldout.dtos.entity.TradeDto;
+import api.soldout.io.soldout.exception.AlreadyMatchedException;
 import api.soldout.io.soldout.repository.trade.TradeRepository;
 import api.soldout.io.soldout.service.sale.SaleService;
 import java.time.LocalDateTime;
@@ -12,7 +12,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
 
 /**
  * .
@@ -34,9 +33,12 @@ public class TradeServiceImpl implements TradeService {
 
     int saleId = findMatchedSaleDto(saleDtoList, size, price);
 
-    // 찾은 saleId가 이미 다른 사용자에 의해 거래 성사가 되었다면 trade 테이블에 해당 saleId가 있어야 한다.
+    // 찾은 saleId로 trade 테이블을 조회한 결과가 한개라도 있다면? 이미 매칭된 saleId 라는 의미
+    if (findBySaleId(saleId).size() > 0) {
 
+      throw new AlreadyMatchedException("이미 다른 구매 희망자와 매칭되었습니다. 다시 즉시 구매를 진행해주세요.");
 
+    }
 
     TradeDto tradeDto = TradeDto.builder()
         .productId(productId)
@@ -67,8 +69,8 @@ public class TradeServiceImpl implements TradeService {
   }
 
   private int findMatchedSaleDto(List<SaleDto> saleDtoList, int size, int price) {
-    // id가 기본적으로 인덱스로 사용되고 자동 증가로 입력되기 때문에 그 순서로 loop를 돈다.
-    // 생성 시기가 빠른 녀석을 찾기 위한 로직이 굳이 필요할지?
+
+    // id가 기본적으로 인덱스로 사용되고 자동 증가로 입력되기 때문에 그 순서로 루프를 수행 -> 생성 시기가 빠른 녀석을 찾기 위한 로직이 굳이 필요할지?
     for (SaleDto tempSaleDto : saleDtoList) {
 
       if (tempSaleDto.getSize() == size && tempSaleDto.getPrice() == price) {
@@ -79,6 +81,8 @@ public class TradeServiceImpl implements TradeService {
 
     }
 
+    // 그래도 찾고자 하는 saleId가 없다면?
+    // 어떠한 이유로 구매 버튼을 누른 시점에 존재했던 SaleId가 없어진 경우
     throw new RuntimeException("판매 입찰 기간이 지나서 갑작스럽게 매칭 가능한 판매자가 사라진 경우");
 
   }

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
@@ -6,8 +6,9 @@ import static api.soldout.io.soldout.dtos.entity.TradeDto.TradeStatus.TRADE_SIGN
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
 import api.soldout.io.soldout.dtos.entity.TradeDto;
+import api.soldout.io.soldout.exception.AlreadyMatchedException;
+import api.soldout.io.soldout.repository.sale.SaleRepository;
 import api.soldout.io.soldout.repository.trade.TradeRepository;
-import api.soldout.io.soldout.service.sale.SaleService;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,14 +24,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TradeServiceImpl implements TradeService {
 
-  private final SaleService saleService;
-
   private final TradeRepository tradeRepository;
+
+  private final SaleRepository saleRepository;
 
   @Override
   public void signTradeByOrder(int productId, int orderId, int size, int price) {
 
-    List<SaleDto> saleDtoList = saleService.findByProductId(productId);
+    List<SaleDto> saleDtoList = saleRepository.findByProductId(productId);
 
     int saleId = findMatchedSaleDto(saleDtoList, size, price);
 
@@ -46,7 +47,7 @@ public class TradeServiceImpl implements TradeService {
 
     tradeRepository.saveTrade(tradeDto);
 
-    saleService.updateSaleStatus(saleId, SALE_SIGNED);
+    saleRepository.updateSaleStatus(saleId, SALE_SIGNED);
 
   }
 
@@ -67,7 +68,7 @@ public class TradeServiceImpl implements TradeService {
   private int findMatchedSaleDto(List<SaleDto> saleDtoList, int size, int price) {
 
     // id가 기본적으로 인덱스로 사용되고 자동 증가로 입력되기 때문에 그 순서로 루프를 수행
-    // 판매 상태가 상태 판매 입찰중이면서 가격과 사이즈가 같은 녀석을 찾도록!!!!!!
+    // 판매 상태가 상태 판매 입찰중이면서 가격과 사이즈가 같은 녀석을 조회
     for (SaleDto tempSaleDto : saleDtoList) {
 
       if (tempSaleDto.getStatus().equals(SALE_PROGRESS)
@@ -80,7 +81,7 @@ public class TradeServiceImpl implements TradeService {
 
     }
 
-    throw new RuntimeException("어떠한 이유로 매칭되어야 할 판매 입찰가가 사라진 경우");
+    throw new AlreadyMatchedException("어떠한 이유로 매칭되어야 할 판매 입찰가가 사라진 경우");
 
   }
 

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
@@ -6,7 +6,7 @@ import api.soldout.io.soldout.dtos.entity.SaleDto;
 import api.soldout.io.soldout.dtos.entity.TradeDto;
 import api.soldout.io.soldout.repository.trade.TradeRepository;
 import api.soldout.io.soldout.service.sale.SaleService;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,7 +37,7 @@ public class TradeServiceImpl implements TradeService {
         .size(size)
         .price(price)
         .status(TRADE_SIGNING)
-        .day(LocalDate.now())
+        .day(LocalDateTime.now())
         .build();
 
     tradeRepository.saveTrade(tradeDto);

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
@@ -28,7 +28,7 @@ public class TradeServiceImpl implements TradeService {
   private final SaleRepository saleRepository;
 
   @Override
-  public void matchTradeByOrder(int productId, int orderId, int size, int price) {
+  public void matchTradeByOrder(int orderId, int productId, int size, int price) {
 
     List<SaleDto> saleDtoList = saleRepository.findByProductId(productId);
 

--- a/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
+++ b/src/main/java/api/soldout/io/soldout/service/trade/TradeServiceImpl.java
@@ -1,5 +1,6 @@
 package api.soldout.io.soldout.service.trade;
 
+import static api.soldout.io.soldout.dtos.entity.TradeDto.TradeStatus.DELIVER_FROM_SALE_COMPLETE;
 import static api.soldout.io.soldout.dtos.entity.TradeDto.TradeStatus.TRADE_SIGNING;
 
 import api.soldout.io.soldout.dtos.entity.SaleDto;
@@ -9,12 +10,15 @@ import api.soldout.io.soldout.service.sale.SaleService;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
 
 /**
  * .
  */
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TradeServiceImpl implements TradeService {
@@ -30,6 +34,10 @@ public class TradeServiceImpl implements TradeService {
 
     int saleId = findMatchedSaleDto(saleDtoList, size, price);
 
+    // 찾은 saleId가 이미 다른 사용자에 의해 거래 성사가 되었다면 trade 테이블에 해당 saleId가 있어야 한다.
+
+
+
     TradeDto tradeDto = TradeDto.builder()
         .productId(productId)
         .orderId(orderId)
@@ -44,8 +52,23 @@ public class TradeServiceImpl implements TradeService {
 
   }
 
-  private int findMatchedSaleDto(List<SaleDto> saleDtoList, int size, int price) {
+  @Override
+  public List<TradeDto> findByOrderId(int orderId) {
 
+    return tradeRepository.findByOrderId(orderId);
+
+  }
+
+  @Override
+  public List<TradeDto> findBySaleId(int saleId) {
+
+    return tradeRepository.findBySaleId(saleId);
+
+  }
+
+  private int findMatchedSaleDto(List<SaleDto> saleDtoList, int size, int price) {
+    // id가 기본적으로 인덱스로 사용되고 자동 증가로 입력되기 때문에 그 순서로 loop를 돈다.
+    // 생성 시기가 빠른 녀석을 찾기 위한 로직이 굳이 필요할지?
     for (SaleDto tempSaleDto : saleDtoList) {
 
       if (tempSaleDto.getSize() == size && tempSaleDto.getPrice() == price) {
@@ -56,7 +79,7 @@ public class TradeServiceImpl implements TradeService {
 
     }
 
-    return 0;
+    throw new RuntimeException("판매 입찰 기간이 지나서 갑작스럽게 매칭 가능한 판매자가 사라진 경우");
 
   }
 

--- a/src/main/resources/db/migration/V5.2__alter_table_sale_add_sale_status.sql
+++ b/src/main/resources/db/migration/V5.2__alter_table_sale_add_sale_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sale
+ADD sale_status varchar(255);

--- a/src/main/resources/db/migration/V5.3__alter_table_order_add_order_status.sql
+++ b/src/main/resources/db/migration/V5.3__alter_table_order_add_order_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `order`
+ADD order_status varchar(255);

--- a/src/main/resources/db/migration/V5.4__alter_table_order_sale_trade_rename_column.sql
+++ b/src/main/resources/db/migration/V5.4__alter_table_order_sale_trade_rename_column.sql
@@ -5,4 +5,4 @@ ALTER TABLE sale
 RENAME COLUMN expiration_day TO expiration_date;
 
 ALTER TABLE trade
-RENAME COLUMN signing_day TO signing_date;
+RENAME COLUMN signing_date TO matching_date;

--- a/src/main/resources/db/migration/V5.4__alter_table_order_sale_trade_rename_expiration_day.sql
+++ b/src/main/resources/db/migration/V5.4__alter_table_order_sale_trade_rename_expiration_day.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `order`
+RENAME COLUMN expiration_day TO expiration_date;
+
+ALTER TABLE sale
+RENAME COLUMN expiration_day TO expiration_date;
+
+ALTER TABLE trade
+RENAME COLUMN signing_day TO signing_date;

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -5,8 +5,8 @@
 <mapper namespace="api.soldout.io.soldout.mapper.OrderMapper">
 
   <insert id="insertOrder" parameterType="api.soldout.io.soldout.dtos.entity.OrderDto" useGeneratedKeys = "true" keyProperty="id">
-    INSERT INTO `order` (user_id, product_id, size, price, order_type, expiration_day)
-    VALUES (#{userId}, #{productId}, #{size}, #{price}, #{type}, #{day});
+    INSERT INTO `order` (user_id, product_id, size, price, expiration_day, order_type, order_status)
+    VALUES (#{userId}, #{productId}, #{size}, #{price}, #{day}, #{type}, #{status});
   </insert>
 
   <resultMap id="orderMap" type="api.soldout.io.soldout.dtos.entity.OrderDto">
@@ -16,8 +16,9 @@
     <result property="size" column="size"></result>
     <result property="price" column="price"></result>
     <result property="type" column="order_type"></result>
-    <result property="period" column="expiration_period"></result>
     <result property="day" column="expiration_day"></result>
+    <result property="period" column="expiration_period"></result>
+    <result property="status" column="order_status"></result>
   </resultMap>
 
   <select id="findByUserId" parameterType="java.lang.String" resultMap="orderMap">
@@ -31,5 +32,11 @@
     FROM `order`
     WHERE product_id = #{productId};
   </select>
+
+  <update id="updateOrderStatus">
+    UPDATE `order`
+    SET order_status = #{status}
+    WHERE id = #{orderId};
+  </update>
 
 </mapper>

--- a/src/main/resources/mapper/OrderMapper.xml
+++ b/src/main/resources/mapper/OrderMapper.xml
@@ -5,8 +5,8 @@
 <mapper namespace="api.soldout.io.soldout.mapper.OrderMapper">
 
   <insert id="insertOrder" parameterType="api.soldout.io.soldout.dtos.entity.OrderDto" useGeneratedKeys = "true" keyProperty="id">
-    INSERT INTO `order` (user_id, product_id, size, price, expiration_day, order_type, order_status)
-    VALUES (#{userId}, #{productId}, #{size}, #{price}, #{day}, #{type}, #{status});
+    INSERT INTO `order` (user_id, product_id, size, price, expiration_date, order_type, order_status)
+    VALUES (#{userId}, #{productId}, #{size}, #{price}, #{date}, #{type}, #{status});
   </insert>
 
   <resultMap id="orderMap" type="api.soldout.io.soldout.dtos.entity.OrderDto">
@@ -15,9 +15,9 @@
     <result property="productId" column="product_id"></result>
     <result property="size" column="size"></result>
     <result property="price" column="price"></result>
-    <result property="type" column="order_type"></result>
-    <result property="day" column="expiration_day"></result>
+    <result property="date" column="expiration_date"></result>
     <result property="period" column="expiration_period"></result>
+    <result property="type" column="order_type"></result>
     <result property="status" column="order_status"></result>
   </resultMap>
 

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -5,8 +5,8 @@
 <mapper namespace="api.soldout.io.soldout.mapper.SaleMapper">
 
   <insert id="insertSale" parameterType="api.soldout.io.soldout.dtos.entity.SaleDto" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO sale (user_id, product_id, size, price, sale_type, expiration_day)
-    VALUES (#{userId}, #{productId}, #{size}, #{price}, #{type}, #{day});
+    INSERT INTO sale (user_id, product_id, size, price, expiration_day, sale_type, sale_status)
+    VALUES (#{userId}, #{productId}, #{size}, #{price},#{day}, #{type}, #{status});
   </insert>
 
   <resultMap id="SaleMap" type="api.soldout.io.soldout.dtos.entity.SaleDto">
@@ -15,8 +15,9 @@
     <result property="productId" column="product_id"></result>
     <result property="size" column="size"></result>
     <result property="price" column="price"></result>
-    <result property="type" column="Sale_type"></result>
     <result property="day" column="expiration_day"></result>
+    <result property="type" column="Sale_type"></result>
+    <result property="status" column="sale_status"></result>
   </resultMap>
 
   <select id="findByUserId" resultMap="SaleMap">

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -5,8 +5,8 @@
 <mapper namespace="api.soldout.io.soldout.mapper.SaleMapper">
 
   <insert id="insertSale" parameterType="api.soldout.io.soldout.dtos.entity.SaleDto" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO sale (user_id, product_id, size, price, expiration_day, sale_type, sale_status)
-    VALUES (#{userId}, #{productId}, #{size}, #{price},#{day}, #{type}, #{status});
+    INSERT INTO sale (user_id, product_id, size, price, expiration_date, sale_type, sale_status)
+    VALUES (#{userId}, #{productId}, #{size}, #{price},#{date}, #{type}, #{status});
   </insert>
 
   <resultMap id="SaleMap" type="api.soldout.io.soldout.dtos.entity.SaleDto">
@@ -15,7 +15,7 @@
     <result property="productId" column="product_id"></result>
     <result property="size" column="size"></result>
     <result property="price" column="price"></result>
-    <result property="day" column="expiration_day"></result>
+    <result property="date" column="expiration_date"></result>
     <result property="type" column="Sale_type"></result>
     <result property="status" column="sale_status"></result>
   </resultMap>

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -32,4 +32,10 @@
     WHERE product_id = #{productId};
   </select>
 
+  <update id="updateSaleStatus">
+    UPDATE sale
+    SET sale_status = #{status}
+    WHERE id = #{saleId};
+  </update>
+
 </mapper>

--- a/src/main/resources/mapper/TradeMapper.xml
+++ b/src/main/resources/mapper/TradeMapper.xml
@@ -4,8 +4,8 @@
 
 <mapper namespace="api.soldout.io.soldout.mapper.TradeMapper">
   <insert id="insertTrade" parameterType="api.soldout.io.soldout.dtos.entity.TradeDto" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO trade (product_id, order_id, sale_id, size, price, trade_status, signing_day)
-    VALUES (#{productId}, #{orderId}, #{saleId}, #{size}, #{price}, #{status}, #{day});
+    INSERT INTO trade (product_id, order_id, sale_id, size, price, trade_status, signing_date)
+    VALUES (#{productId}, #{orderId}, #{saleId}, #{size}, #{price}, #{status}, #{date});
   </insert>
 
   <resultMap id="TradeMap" type="api.soldout.io.soldout.dtos.entity.TradeDto">
@@ -16,18 +16,18 @@
     <result property="size" column="size"></result>
     <result property="price" column="price"></result>
     <result property="status" column="trade_status"></result>
-    <result property="day" column="signing_day"></result>
+    <result property="date" column="signing_date"></result>
   </resultMap>
 
   <select id="findByOrderId" resultMap="TradeMap">
     SELECT *
-    FROM Trade
+    FROM trade
     WHERE order_id = #{orderId};
   </select>
 
   <select id="findBySaleId" resultMap="TradeMap">
     SELECT *
-    FROM Trade
+    FROM trade
     WHERE sale_id = #{saleId};
   </select>
 </mapper>

--- a/src/main/resources/mapper/TradeMapper.xml
+++ b/src/main/resources/mapper/TradeMapper.xml
@@ -7,4 +7,27 @@
     INSERT INTO trade (product_id, order_id, sale_id, size, price, trade_status, signing_day)
     VALUES (#{productId}, #{orderId}, #{saleId}, #{size}, #{price}, #{status}, #{day});
   </insert>
+
+  <resultMap id="TradeMap" type="api.soldout.io.soldout.dtos.entity.TradeDto">
+    <id property="id" column="id"></id>
+    <result property="productId" column="product_id"></result>
+    <result property="orderId" column="order_id"></result>
+    <result property="saleId" column="sale_id"></result>
+    <result property="size" column="size"></result>
+    <result property="price" column="price"></result>
+    <result property="status" column="trade_status"></result>
+    <result property="day" column="signing_day"></result>
+  </resultMap>
+
+  <select id="findByOrderId" resultMap="TradeMap">
+    SELECT *
+    FROM Trade
+    WHERE order_id = #{orderId};
+  </select>
+
+  <select id="findBySaleId" resultMap="TradeMap">
+    SELECT *
+    FROM Trade
+    WHERE sale_id = #{saleId};
+  </select>
 </mapper>

--- a/src/main/resources/mapper/TradeMapper.xml
+++ b/src/main/resources/mapper/TradeMapper.xml
@@ -4,7 +4,7 @@
 
 <mapper namespace="api.soldout.io.soldout.mapper.TradeMapper">
   <insert id="insertTrade" parameterType="api.soldout.io.soldout.dtos.entity.TradeDto" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO trade (product_id, order_id, sale_id, size, price, trade_status, signing_date)
+    INSERT INTO trade (product_id, order_id, sale_id, size, price, trade_status, matching_date)
     VALUES (#{productId}, #{orderId}, #{saleId}, #{size}, #{price}, #{status}, #{date});
   </insert>
 
@@ -16,7 +16,7 @@
     <result property="size" column="size"></result>
     <result property="price" column="price"></result>
     <result property="status" column="trade_status"></result>
-    <result property="date" column="signing_date"></result>
+    <result property="date" column="matching_date"></result>
   </resultMap>
 
   <select id="findByOrderId" resultMap="TradeMap">

--- a/src/test/java/api/soldout/io/soldout/service/order/OrderServiceImplTest.java
+++ b/src/test/java/api/soldout/io/soldout/service/order/OrderServiceImplTest.java
@@ -1,14 +1,21 @@
 package api.soldout.io.soldout.service.order;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import api.soldout.io.soldout.repository.order.OrderRepository;
+import api.soldout.io.soldout.service.order.command.OrderCommand;
 import api.soldout.io.soldout.service.trade.TradeService;
-import lombok.extern.slf4j.Slf4j;
+import api.soldout.io.soldout.util.enums.OrderType;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@Slf4j
 @ExtendWith(MockitoExtension.class)
 class OrderServiceImplTest {
 
@@ -24,6 +31,26 @@ class OrderServiceImplTest {
   void init() {
 
     orderService = new OrderServiceImpl(orderRepository, tradeService);
+
+  }
+
+  @Test
+  @DisplayName("즉시 구매 테스트")
+  void orderNowTest() {
+    // given
+    OrderCommand command = new OrderCommand(
+        1, 1, 250, 100000, 3, OrderType.ORDER_NOW
+    );
+
+    // when
+    orderService.orderNow(command);
+
+    // then
+    verify(orderRepository).saveOrder(any());
+    verify(orderRepository, times(1)).saveOrder(any());
+
+    verify(tradeService).signTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
+    verify(tradeService, times(1)).signTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
 
   }
 

--- a/src/test/java/api/soldout/io/soldout/service/order/OrderServiceImplTest.java
+++ b/src/test/java/api/soldout/io/soldout/service/order/OrderServiceImplTest.java
@@ -56,9 +56,9 @@ class OrderServiceImplTest {
         .saveOrder(any());
 
     verify(tradeService)
-        .signTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
+        .matchTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
     verify(tradeService, times(1))
-        .signTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
+        .matchTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
 
     verify(orderRepository)
         .updateOrderStatus(anyInt(), any());

--- a/src/test/java/api/soldout/io/soldout/service/order/OrderServiceImplTest.java
+++ b/src/test/java/api/soldout/io/soldout/service/order/OrderServiceImplTest.java
@@ -2,18 +2,20 @@ package api.soldout.io.soldout.service.order;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import api.soldout.io.soldout.repository.order.OrderRepository;
+import api.soldout.io.soldout.repository.order.OrderRepositoryImpl;
 import api.soldout.io.soldout.service.order.command.OrderCommand;
 import api.soldout.io.soldout.service.trade.TradeService;
+import api.soldout.io.soldout.service.trade.TradeServiceImpl;
 import api.soldout.io.soldout.util.enums.OrderType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,14 +23,16 @@ class OrderServiceImplTest {
 
   OrderService orderService;
 
-  @Mock
   OrderRepository orderRepository;
 
-  @Mock
   TradeService tradeService;
 
   @BeforeEach
   void init() {
+
+    orderRepository = mock(OrderRepositoryImpl.class);
+
+    tradeService = mock(TradeServiceImpl.class);
 
     orderService = new OrderServiceImpl(orderRepository, tradeService);
 
@@ -46,11 +50,20 @@ class OrderServiceImplTest {
     orderService.orderNow(command);
 
     // then
-    verify(orderRepository).saveOrder(any());
-    verify(orderRepository, times(1)).saveOrder(any());
+    verify(orderRepository)
+        .saveOrder(any());
+    verify(orderRepository, times(1))
+        .saveOrder(any());
 
-    verify(tradeService).signTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
-    verify(tradeService, times(1)).signTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
+    verify(tradeService)
+        .signTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
+    verify(tradeService, times(1))
+        .signTradeByOrder(anyInt(), anyInt(), anyInt(), anyInt());
+
+    verify(orderRepository)
+        .updateOrderStatus(anyInt(), any());
+    verify(orderRepository, times(1))
+        .updateOrderStatus(anyInt(), any());
 
   }
 

--- a/src/test/java/api/soldout/io/soldout/service/order/OrderServiceImplTest.java
+++ b/src/test/java/api/soldout/io/soldout/service/order/OrderServiceImplTest.java
@@ -1,0 +1,30 @@
+package api.soldout.io.soldout.service.order;
+
+import api.soldout.io.soldout.repository.order.OrderRepository;
+import api.soldout.io.soldout.service.trade.TradeService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class OrderServiceImplTest {
+
+  OrderService orderService;
+
+  @Mock
+  OrderRepository orderRepository;
+
+  @Mock
+  TradeService tradeService;
+
+  @BeforeEach
+  void init() {
+
+    orderService = new OrderServiceImpl(orderRepository, tradeService);
+
+  }
+
+}

--- a/src/test/java/api/soldout/io/soldout/service/trade/TradeServiceImplTest.java
+++ b/src/test/java/api/soldout/io/soldout/service/trade/TradeServiceImplTest.java
@@ -72,7 +72,7 @@ class TradeServiceImplTest {
     when(saleRepository.findByProductId(productId))
         .thenReturn(saleDtoList);
 
-    tradeService.signTradeByOrder(productId, orderId, size, price);
+    tradeService.matchTradeByOrder(productId, orderId, size, price);
 
     // then
     assertThat(saleRepository.findByProductId(productId))

--- a/src/test/java/api/soldout/io/soldout/service/trade/TradeServiceImplTest.java
+++ b/src/test/java/api/soldout/io/soldout/service/trade/TradeServiceImplTest.java
@@ -1,20 +1,27 @@
 package api.soldout.io.soldout.service.trade;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import api.soldout.io.soldout.dtos.entity.SaleDto;
+import api.soldout.io.soldout.dtos.entity.SaleDto.SaleStatus;
 import api.soldout.io.soldout.repository.sale.SaleRepository;
+import api.soldout.io.soldout.repository.sale.SaleRepositoryImpl;
 import api.soldout.io.soldout.repository.trade.TradeRepository;
-import api.soldout.io.soldout.service.sale.SaleService;
-import org.junit.jupiter.api.Assertions;
+import api.soldout.io.soldout.repository.trade.TradeRepositoryImpl;
+import api.soldout.io.soldout.util.enums.SaleType;
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,44 +29,67 @@ class TradeServiceImplTest {
 
   private TradeService tradeService;
 
-  @Mock
   private SaleRepository saleRepository;
 
-  @Mock
   private TradeRepository tradeRepository;
-
-  private TradeService tradeService(
-      TradeRepository tradeRepository, SaleRepository saleRepository) {
-
-    return new TradeServiceImpl(tradeRepository, saleRepository);
-
-  }
-
 
   @BeforeEach
   void init() {
 
-    tradeService = tradeService(tradeRepository, saleRepository);
+    saleRepository = mock(SaleRepositoryImpl.class);
+
+    tradeRepository = mock(TradeRepositoryImpl.class);
+
+    tradeService = new TradeServiceImpl(tradeRepository, saleRepository);
 
   }
 
   @Test
-  @DisplayName("즉시 구매 요청에 따른 거래 채결 텟스트")
-  @Disabled
+  @DisplayName("즉시 구매 요청에 따른 거래 채결 테스트")
   void signTradeByOrderTest() {
     // given
     int productId = 1;
     int orderId = 1;
     int size = 250;
     int price = 100000;
+
+    SaleDto saleDto = SaleDto.builder()
+        .id(1)
+        .productId(productId)
+        .userId(1)
+        .size(size)
+        .price(price)
+        .date(3)
+        .type(SaleType.SALE_BID)
+        .status(SaleStatus.BID_PROGRESS)
+        .build();
+
+    List<SaleDto> saleDtoList = new ArrayList<>();
+    saleDtoList.add(saleDto);
+
+
     // when
-    // tradeService.signTradeByOrder(productId, orderId, size, price);
+    when(saleRepository.findByProductId(productId))
+        .thenReturn(saleDtoList);
 
-    //then
-    // verify(saleRepository).findByProductId(productId);
-    // verify(saleRepository, times(1)).findByProductId(productId);
+    tradeService.signTradeByOrder(productId, orderId, size, price);
 
-    // verify(tradeRepository).saveTrade(any());
-    // verify(tradeRepository, times(1)).saveTrade(any());
+    // then
+    assertThat(saleRepository.findByProductId(productId))
+        .isEqualTo(saleDtoList);
+
+    verify(tradeRepository)
+        .saveTrade(any());
+
+    verify(tradeRepository, times(1))
+        .saveTrade(any());
+
+    verify(saleRepository)
+        .updateSaleStatus(saleDto.getId(), SaleStatus.MATCHING_COMPLETE);
+
+    verify(saleRepository, times(1))
+        .updateSaleStatus(saleDto.getId(), SaleStatus.MATCHING_COMPLETE);
+
   }
+
 }

--- a/src/test/java/api/soldout/io/soldout/service/trade/TradeServiceImplTest.java
+++ b/src/test/java/api/soldout/io/soldout/service/trade/TradeServiceImplTest.java
@@ -3,10 +3,14 @@ package api.soldout.io.soldout.service.trade;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import api.soldout.io.soldout.repository.sale.SaleRepository;
 import api.soldout.io.soldout.repository.trade.TradeRepository;
 import api.soldout.io.soldout.service.sale.SaleService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,14 +23,15 @@ class TradeServiceImplTest {
   private TradeService tradeService;
 
   @Mock
-  private SaleService saleService;
+  private SaleRepository saleRepository;
 
   @Mock
   private TradeRepository tradeRepository;
 
-  private TradeService tradeService(SaleService saleService, TradeRepository tradeRepository) {
+  private TradeService tradeService(
+      TradeRepository tradeRepository, SaleRepository saleRepository) {
 
-    return new TradeServiceImpl(saleService, tradeRepository);
+    return new TradeServiceImpl(tradeRepository, saleRepository);
 
   }
 
@@ -34,27 +39,27 @@ class TradeServiceImplTest {
   @BeforeEach
   void init() {
 
-    tradeService = tradeService(saleService, tradeRepository);
+    tradeService = tradeService(tradeRepository, saleRepository);
 
   }
 
   @Test
   @DisplayName("즉시 구매 요청에 따른 거래 채결 텟스트")
+  @Disabled
   void signTradeByOrderTest() {
     // given
     int productId = 1;
     int orderId = 1;
     int size = 250;
     int price = 100000;
-
     // when
-    tradeService.signTradeByOrder(productId, orderId, size, price);
+    // tradeService.signTradeByOrder(productId, orderId, size, price);
 
     //then
-    verify(saleService).findByProductId(productId);
-    verify(saleService, times(1)).findByProductId(productId);
+    // verify(saleRepository).findByProductId(productId);
+    // verify(saleRepository, times(1)).findByProductId(productId);
 
-    verify(tradeRepository).saveTrade(any());
-    verify(tradeRepository, times(1)).saveTrade(any());
+    // verify(tradeRepository).saveTrade(any());
+    // verify(tradeRepository, times(1)).saveTrade(any());
   }
 }


### PR DESCRIPTION
즉시 구매 기능에 실제로 판매 입찰자와 매칭시켜주는 로직을 구현해 봤습니다!!

**주요 내용**

- **주문 or 판매 입찰 등록시 현재 상태를 관리해줄 필드 및 컬럼 추가**
  - `OrderStatus`, `SaleStatus` 이름의 enum클래스를 추가
 
- **이에 따른 update 메서드 추가(`updateOrderStatus()`, `updateSaleStatus()`)**
  - 거래 채결 시(= tradeDto 생성에 성공했을 시) `OrderStatus`와 `SaleStatus` 값을 변경하는 역할

- **TradeServiceImpl의 의존성 주입 대상을 Service에서 Repository로 변경**