### PR TITLE
Redis 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,14 @@ repositories {
 }
 
 dependencies {
-	//
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
+
+	// MyBatis
 	testCompileOnly 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.0'
 
-	// flyway
+	// Flyway
 	implementation 'org.flywaydb:flyway-core:5.2.4'
 
 	// Database

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.session:spring-session-data-redis'
+	// implementation 'org.springframework.session:spring-session-data-redis'
 
 	// MyBatis
 	testCompileOnly 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.2.0'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,3 +14,11 @@ services:
     ports:
       - "3306:3306"
     restart: always
+
+  redis-docker:
+    container_name: soldout-redis
+    image: redis:latest
+    volumes:
+      - ./example-docker-data/redis:/data
+    ports:
+      - "6379:6379"

--- a/src/main/java/api/soldout/io/soldout/SoldoutApplication.java
+++ b/src/main/java/api/soldout/io/soldout/SoldoutApplication.java
@@ -2,11 +2,13 @@ package api.soldout.io.soldout;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 /**
  * .
  */
 
+//@EnableRedisHttpSession
 @SpringBootApplication
 public class SoldoutApplication {
   public static void main(String[] args) {

--- a/src/main/java/api/soldout/io/soldout/SoldoutApplication.java
+++ b/src/main/java/api/soldout/io/soldout/SoldoutApplication.java
@@ -2,11 +2,13 @@ package api.soldout.io.soldout;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 /**
  * .
- * */
+ */
 
+@EnableRedisHttpSession
 @SpringBootApplication
 public class SoldoutApplication {
   public static void main(String[] args) {

--- a/src/main/java/api/soldout/io/soldout/SoldoutApplication.java
+++ b/src/main/java/api/soldout/io/soldout/SoldoutApplication.java
@@ -2,13 +2,11 @@ package api.soldout.io.soldout;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 /**
  * .
  */
 
-//@EnableRedisHttpSession
 @SpringBootApplication
 public class SoldoutApplication {
   public static void main(String[] args) {

--- a/src/main/java/api/soldout/io/soldout/SoldoutApplication.java
+++ b/src/main/java/api/soldout/io/soldout/SoldoutApplication.java
@@ -2,13 +2,11 @@ package api.soldout.io.soldout;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 /**
  * .
  */
 
-@EnableRedisHttpSession
 @SpringBootApplication
 public class SoldoutApplication {
   public static void main(String[] args) {

--- a/src/main/java/api/soldout/io/soldout/config/RedisConfig.java
+++ b/src/main/java/api/soldout/io/soldout/config/RedisConfig.java
@@ -1,0 +1,48 @@
+package api.soldout.io.soldout.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * .
+ */
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.redis.port}")
+  private int redisPort;
+
+  /**
+   * .
+   */
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+
+    return new LettuceConnectionFactory(redisHost, redisPort);
+
+  }
+
+  /**
+   * .
+   */
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+    return redisTemplate;
+  }
+}

--- a/src/main/java/api/soldout/io/soldout/service/security/RedisSessionSecurityService.java
+++ b/src/main/java/api/soldout/io/soldout/service/security/RedisSessionSecurityService.java
@@ -100,7 +100,7 @@ public class RedisSessionSecurityService implements SecurityService {
 
       return true;
 
-    } else if (redisTemplate.opsForValue().get(SecurityUtil.SESSION_ID) != null) {
+    } else if (redisTemplate.opsForValue().get(sessionId) != null) {
 
       return true;
 

--- a/src/main/java/api/soldout/io/soldout/service/security/RedisSessionSecurityService.java
+++ b/src/main/java/api/soldout/io/soldout/service/security/RedisSessionSecurityService.java
@@ -1,0 +1,112 @@
+package api.soldout.io.soldout.service.security;
+
+
+import api.soldout.io.soldout.exception.AlreadySignInBrowserException;
+import api.soldout.io.soldout.exception.NotSignInBrowserException;
+import api.soldout.io.soldout.util.SecurityUtil;
+import java.time.Duration;
+import java.util.UUID;
+import javax.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * .
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisSessionSecurityService implements SecurityService {
+
+  private final HttpSession session;
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  @Value("${spring.redis.session.timeout}")
+  private int timeout;
+
+  @Override
+  public void signIn(int userId) {
+
+    if (isAlreadySignInBrowser(getCurrentSessionId())) {
+
+      throw new AlreadySignInBrowserException("이미 로그인한 상태입니다.");
+
+    }
+
+    String token = UUID.randomUUID().toString();
+
+    redisTemplate.opsForValue().set(token, String.valueOf(userId));
+
+    redisTemplate.expire(String.valueOf(userId), Duration.ofSeconds(timeout));
+
+    session.setAttribute(SecurityUtil.SESSION_ID, token);
+
+    session.setMaxInactiveInterval(timeout);
+
+  }
+
+  @Override
+  public void logOut() {
+
+    if (!isAlreadySignInBrowser(getCurrentSessionId())) {
+
+      throw new NotSignInBrowserException("로그인한 상태가 아닙니다.");
+
+    }
+
+    redisTemplate.delete(getCurrentSessionId());
+
+    session.invalidate();
+
+  }
+
+  @Override
+  public int getCurrentUserId() {
+
+    String userId = (String) redisTemplate.opsForValue().get(getCurrentSessionId());
+
+    if (userId == null) {
+
+      throw new NotSignInBrowserException("로그인한 회원 정보가 없습니다.");
+
+    }
+
+    return Integer.parseInt(userId);
+
+  }
+
+  /**
+   * .
+   */
+
+  private String getCurrentSessionId() {
+
+    return (String) session.getAttribute(SecurityUtil.SESSION_ID);
+
+  }
+
+  /**
+   * .
+   */
+
+  private boolean isAlreadySignInBrowser(String sessionId) {
+
+    if (sessionId != null) {
+
+      return true;
+
+    } else if (redisTemplate.opsForValue().get(SecurityUtil.SESSION_ID) != null) {
+
+      return true;
+
+    }
+
+    return false;
+
+  }
+}

--- a/src/main/java/api/soldout/io/soldout/service/security/SessionSecurityService.java
+++ b/src/main/java/api/soldout/io/soldout/service/security/SessionSecurityService.java
@@ -27,7 +27,6 @@ import org.springframework.stereotype.Service;
  **/
 
 @Slf4j
-@Service
 @RequiredArgsConstructor
 public class SessionSecurityService implements SecurityService {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,13 @@ spring:
     enabled: true
     baseline-on-migrate: true
 
+  redis:
+    host: localhost
+    port: 6379
+    session:
+      timeout: 10
+      store-type: redis
+
 mybatis:
   type-aliases-package: api.soldout.io.soldout.mapper
   mapper-locations: classpath:mapper/*.xml


### PR DESCRIPTION
### 작업 내용
1. Docker-compose 로 Redis 컨테이너 설치
2. RedisSessionSecurityService 클래스를 생성해 새로운 서비스 구현체 생성

### 궁금한 내용
Main Class에 @EnableRedisHttpSession 을 추가하면 Controller Test 코드에 에러가 발생하는 문제가 있습니다ㅠㅠ
Session Storage를 활용하려면 해당 어노테이션이 추가되어야 한다고 이해해서 일차적으론 주석처리를 해둔 상태입니다...
문제점이 무엇일지 찾아볼만한 키워드가 있다면 알고 싶습니다!!
#### 에러 메세지
```
    java.lang.IllegalStateException: Failed to load ApplicationContext
    
    	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:132)
    	at org.springframework.test.context.support.DefaultTestContext.getApplicationContext(DefaultTestContext.java:124)
    	at org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener.postProcessFields(MockitoTestExecutionListener.java:110)
    	at org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener.injectFields(MockitoTestExecutionListener.java:94)
    	at org.springframework.boot.test.mock.mockito.MockitoTestExecutionListener.prepareTestInstance(MockitoTestExecutionListener.java:61)
    	at org.springframework.test.context.TestContextManager.prepareTestInstance(TestContextManager.java:248)
    	at org.springframework.test.context.junit.jupiter.SpringExtension.postProcessTestInstance(SpringExtension.java:138)
    	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeTestInstancePostProcessors$8(ClassBasedTestDescriptor.java:363)
    	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.executeAndMaskThrowable(ClassBasedTestDescriptor.java:368)
    	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeTestInstancePostProcessors$9(ClassBasedTestDescriptor.java:363)
    	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
    	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
    	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
    	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
    	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
    	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:312)
    	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
    	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734)
    	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
    	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeTestInstancePostProcessors(ClassBasedTestDescriptor.java:362)
    	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$instantiateAndPostProcessTestInstance$6(ClassBasedTestDescriptor.java:283)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.instantiateAndPostProcessTestInstance(ClassBasedTestDescriptor.java:282)
    	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$4(ClassBasedTestDescriptor.java:272)
    	at java.base/java.util.Optional.orElseGet(Optional.java:369)
    	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$testInstancesProvider$5(ClassBasedTestDescriptor.java:271)
    	at org.junit.jupiter.engine.execution.TestInstancesProvider.getTestInstances(TestInstancesProvider.java:31)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$prepare$0(TestMethodTestDescriptor.java:102)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:101)
    	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.prepare(TestMethodTestDescriptor.java:66)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$prepare$2(NodeTestTask.java:123)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.prepare(NodeTestTask.java:123)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:90)
    	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
    	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
    	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
    	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
    	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
    	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
    	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
    	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
    	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
    	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
    	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
    	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
    	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:71)
    	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
    	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
    	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
    	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
    	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
    Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration$SessionCleanupConfiguration': Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration': Injection of autowired dependencies failed; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.springframework.data.redis.connection.RedisConnectionFactory' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
    	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:800)
    	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:229)
    	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1372)
    	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1222)
    	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
    	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
    	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
    	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
    	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
    	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
    	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:953)
    	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:918)
    	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583)
    	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:740)
    	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:415)
    	at org.springframework.boot.SpringApplication.run(SpringApplication.java:303)
    	at org.springframework.boot.test.context.SpringBootContextLoader.loadContext(SpringBootContextLoader.java:136)
    	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContextInternal(DefaultCacheAwareContextLoaderDelegate.java:99)
    	at org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:124)
    	... 72 more
    Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration': Injection of autowired dependencies failed; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.springframework.data.redis.connection.RedisConnectionFactory' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
    	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:405)
    	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1431)
    	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:619)
    	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
    	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
    	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
    	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
    	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
    	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:276)
    	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1389)
    	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1309)
    	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:887)
    	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:791)
    	... 90 more
    Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.springframework.data.redis.connection.RedisConnectionFactory' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
    	at org.springframework.beans.factory.support.DefaultListableBeanFactory.raiseNoMatchingBeanFound(DefaultListableBeanFactory.java:1799)
    	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1355)
    	at org.springframework.beans.factory.support.DefaultListableBeanFactory$DependencyObjectProvider.getObject(DefaultListableBeanFactory.java:1988)
    	at org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration.setRedisConnectionFactory(RedisHttpSessionConfiguration.java:209)
    	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredMethodElement.inject(AutowiredAnnotationBeanPostProcessor.java:724)
    	at org.springframework.beans.factory.annotation.InjectionMetadata.inject(InjectionMetadata.java:119)
    	at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor.postProcessProperties(AutowiredAnnotationBeanPostProcessor.java:399)
    	... 102 more
    
    Process finished with exit code 255
 ```