### PR TITLE
APM 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ hs_err_pid*
 build/
 out/
 docker/db
+docker/example-docker-data
+apm-server-7.15.0-darwin-x86_64
+elastic-apm-agent-1.32.0.jar
+apm-server-7.15.0-darwin-x86_64.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,4 @@ out/
 docker/db
 docker/example-docker-data
 apm-server-7.15.0-darwin-x86_64
-elastic-apm-agent-1.32.0.jar
 apm-server-7.15.0-darwin-x86_64.tar.gz

--- a/docker/apm-compose.yml
+++ b/docker/apm-compose.yml
@@ -1,0 +1,50 @@
+version : "3"
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.0
+    container_name: soldout-elastic
+    environment:
+      - node.name=elasticsearch
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=elasticsearch
+      - cluster.initial_master_nodes=elasticsearch
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    #    volumes:
+    #      - ./volume/elasticsearch-volume:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+    networks:
+      - elastic
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.15.0
+    container_name: soldout-kibana
+    ports:
+      - "5601:5601"
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    networks:
+      - elastic
+
+  apm:
+    image: docker.elastic.co/apm/apm-server:7.15.0
+    ports:
+      - "8200:8200"
+    volumes:
+      - ./volume/apm-server:/usr/share/apm-server/data
+    environment:
+      output.elasticsearch.hosts: '["elasticsearch:9200"]'
+
+volumes:
+  elasticsearch-volume:
+    driver: local
+
+networks:
+  elastic:
+    driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,3 +22,52 @@ services:
       - ./example-docker-data/redis:/data
     ports:
       - "6379:6379"
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.3
+    container_name: soldout-elastic
+    environment:
+      - node.name=elasticsearch
+      - cluster.name=es-docker-cluster
+      - discovery.seed_hosts=elasticsearch
+      - cluster.initial_master_nodes=elasticsearch
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - ./volume/elasticsearch-volume:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+    networks:
+      - elastic
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.2.3
+    container_name: soldout-kibana
+    ports:
+      - "5601:5601"
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    networks:
+      - elastic
+
+  apm:
+    image: docker.elastic.co/apm/apm-server:8.2.3
+    ports:
+      - "8200:8200"
+    volumes:
+      - ./volume/apm-server:/usr/share/apm-server/data"
+    environment:
+      output.elasticsearch.hosts: '["elasticsearch:9200"]'
+
+volumes:
+  elasticsearch-volume:
+    driver: local
+
+networks:
+  elastic:
+    driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version : "3.7"
+version : "3"
 services:
   db:
     platform: linux/x86_64
@@ -22,52 +22,3 @@ services:
       - ./example-docker-data/redis:/data
     ports:
       - "6379:6379"
-
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.3
-    container_name: soldout-elastic
-    environment:
-      - node.name=elasticsearch
-      - cluster.name=es-docker-cluster
-      - discovery.seed_hosts=elasticsearch
-      - cluster.initial_master_nodes=elasticsearch
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-    volumes:
-      - ./volume/elasticsearch-volume:/usr/share/elasticsearch/data
-    ports:
-      - "9200:9200"
-    networks:
-      - elastic
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.3
-    container_name: soldout-kibana
-    ports:
-      - "5601:5601"
-    environment:
-      ELASTICSEARCH_URL: http://elasticsearch:9200
-      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
-    networks:
-      - elastic
-
-  apm:
-    image: docker.elastic.co/apm/apm-server:8.2.3
-    ports:
-      - "8200:8200"
-    volumes:
-      - ./volume/apm-server:/usr/share/apm-server/data"
-    environment:
-      output.elasticsearch.hosts: '["elasticsearch:9200"]'
-
-volumes:
-  elasticsearch-volume:
-    driver: local
-
-networks:
-  elastic:
-    driver: bridge

--- a/src/main/java/api/soldout/io/soldout/service/security/RedisSessionSecurityService.java
+++ b/src/main/java/api/soldout/io/soldout/service/security/RedisSessionSecurityService.java
@@ -96,17 +96,17 @@ public class RedisSessionSecurityService implements SecurityService {
 
   private boolean isAlreadySignInBrowser(String sessionId) {
 
-    if (sessionId != null) {
+    if (sessionId == null) {
 
-      return true;
+      return false;
 
-    } else if (redisTemplate.opsForValue().get(SecurityUtil.SESSION_ID) != null) {
+    } else if (redisTemplate.opsForValue().get(sessionId) == null) {
 
-      return true;
+      return false;
 
     }
 
-    return false;
+    return true;
 
   }
 }

--- a/src/main/java/api/soldout/io/soldout/service/security/RedisSessionSecurityService.java
+++ b/src/main/java/api/soldout/io/soldout/service/security/RedisSessionSecurityService.java
@@ -100,7 +100,7 @@ public class RedisSessionSecurityService implements SecurityService {
 
       return true;
 
-    } else if (redisTemplate.opsForValue().get(sessionId) != null) {
+    } else if (redisTemplate.opsForValue().get(SecurityUtil.SESSION_ID) != null) {
 
       return true;
 


### PR DESCRIPTION
APM 설정을 위해 docker-compose 파일에 코드를 추가했습니다!

멘토님과 프로젝트를 진행하신 분들의 레포와 블로그를 참고하고 있는 중입니다!(https://oopsys.tistory.com/284)

문제는 Docker에 설치한 ElasticSearch 서버가 다음과 같은 에러 메세지와 함께 자꾸 다운되는 문제가 생깁니다..ㅠㅠ
```
ERROR: [1] bootstrap checks failed. You must address the points described in the following [1] lines before starting Elasticsearch.

bootstrap check failure [1] of [1]: Transport SSL must be enabled if security is enabled. Please set [xpack.security.transport.ssl.enabled] to [true] or disable security by setting [xpack.security.enabled] to [false]

ERROR: Elasticsearch did not exit normally - check the logs at /usr/share/elasticsearch/logs/es-docker-cluster.log
```

추가로 메모리는 이미 7.9GB 정도로 설정되어 있는 상태였습니다!
